### PR TITLE
hotfix: replace config usage with correct laravel facade

### DIFF
--- a/src/AuthenticationHandler.php
+++ b/src/AuthenticationHandler.php
@@ -2,19 +2,16 @@
 
 namespace Ninja\DeviceTracker;
 
-use Config;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Events\Dispatcher;
-use Ninja\DeviceTracker\DTO\Metadata;
+use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Events\DeviceTrackedEvent;
 use Ninja\DeviceTracker\Events\Google2FASuccess;
 use Ninja\DeviceTracker\Facades\DeviceManager;
 use Ninja\DeviceTracker\Facades\SessionManager;
 use Ninja\DeviceTracker\Models\Device;
 use Ninja\DeviceTracker\Models\Session;
-use Ninja\DeviceTracker\Modules\Tracking\Enums\EventType;
-use Ninja\DeviceTracker\Modules\Tracking\Models\Event;
 
 final readonly class AuthenticationHandler
 {

--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -2,9 +2,9 @@
 
 namespace Ninja\DeviceTracker\Cache;
 
-use Config;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Contracts\Cacheable;
 use Ninja\DeviceTracker\Models\Device;
 use Psr\SimpleCache\InvalidArgumentException;

--- a/src/Cache/DeviceCache.php
+++ b/src/Cache/DeviceCache.php
@@ -2,8 +2,8 @@
 
 namespace Ninja\DeviceTracker\Cache;
 
-use Config;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use Ninja\DeviceTracker\Contracts\Cacheable;
 use Ninja\DeviceTracker\Models\Device;

--- a/src/Cache/LocationCache.php
+++ b/src/Cache/LocationCache.php
@@ -2,7 +2,7 @@
 
 namespace Ninja\DeviceTracker\Cache;
 
-use Config;
+use Illuminate\Support\Facades\Config;
 
 final class LocationCache extends AbstractCache
 {

--- a/src/Cache/SessionCache.php
+++ b/src/Cache/SessionCache.php
@@ -2,8 +2,8 @@
 
 namespace Ninja\DeviceTracker\Cache;
 
-use Config;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use Ninja\DeviceTracker\Contracts\Cacheable;
 use Ninja\DeviceTracker\Models\Session;

--- a/src/Cache/UserAgentCache.php
+++ b/src/Cache/UserAgentCache.php
@@ -2,7 +2,7 @@
 
 namespace Ninja\DeviceTracker\Cache;
 
-use Config;
+use Illuminate\Support\Facades\Config;
 
 final class UserAgentCache extends AbstractCache
 {

--- a/src/DeviceManager.php
+++ b/src/DeviceManager.php
@@ -3,9 +3,9 @@
 namespace Ninja\DeviceTracker;
 
 use Auth;
-use Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
 use Ninja\DeviceTracker\Contracts\StorableId;
 use Ninja\DeviceTracker\Enums\Transport;

--- a/src/DeviceManager.php
+++ b/src/DeviceManager.php
@@ -2,9 +2,9 @@
 
 namespace Ninja\DeviceTracker;
 
-use Auth;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
 use Ninja\DeviceTracker\Contracts\StorableId;

--- a/src/Http/Controllers/SessionController.php
+++ b/src/Http/Controllers/SessionController.php
@@ -7,14 +7,11 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Cache\SessionCache;
-use Ninja\DeviceTracker\Exception\TwoFactorAuthenticationNotEnabled;
 use Ninja\DeviceTracker\Factories\SessionIdFactory;
 use Ninja\DeviceTracker\Http\Resources\SessionResource;
 use Ninja\DeviceTracker\Models\Session;
-use Ninja\DeviceTracker\ValueObject\SessionId;
 use PragmaRX\Google2FA\Exceptions\InvalidAlgorithmException;
 use Ramsey\Uuid\Uuid;
-use Random\RandomException;
 
 /**
  * @authenticated

--- a/src/Http/Controllers/TwoFactorController.php
+++ b/src/Http/Controllers/TwoFactorController.php
@@ -2,11 +2,11 @@
 
 namespace Ninja\DeviceTracker\Http\Controllers;
 
-use Config;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Events\Google2FAFailed;
 use Ninja\DeviceTracker\Events\Google2FASuccess;
 use PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException;

--- a/src/Http/Middleware/SessionTracker.php
+++ b/src/Http/Middleware/SessionTracker.php
@@ -2,7 +2,6 @@
 
 namespace Ninja\DeviceTracker\Http\Middleware;
 
-use Auth;
 use Closure;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Contracts\Auth\Guard;
@@ -10,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Ninja\DeviceTracker\Models\Session;

--- a/src/Modules/Fingerprinting/Http/Middleware/FingerprintTracker.php
+++ b/src/Modules/Fingerprinting/Http/Middleware/FingerprintTracker.php
@@ -3,10 +3,10 @@
 namespace Ninja\DeviceTracker\Modules\Fingerprinting\Http\Middleware;
 
 use Closure;
-use Config;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
 use Ninja\DeviceTracker\Exception\FingerprintDuplicatedException;
 use Ninja\DeviceTracker\Facades\DeviceManager;

--- a/src/Modules/Tracking/Cache/EventTypeCache.php
+++ b/src/Modules/Tracking/Cache/EventTypeCache.php
@@ -2,8 +2,8 @@
 
 namespace Ninja\DeviceTracker\Modules\Tracking\Cache;
 
-use Config;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Cache\AbstractCache;
 use Ninja\DeviceTracker\Contracts\RequestAware;
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -2,11 +2,11 @@
 
 namespace Ninja\DeviceTracker;
 
-use Config;
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session as SessionFacade;
 use Ninja\DeviceTracker\Contracts\StorableId;
 use Ninja\DeviceTracker\Exception\DeviceNotFoundException;


### PR DESCRIPTION
Replaced usages of Config and Auth classes with the correct Illuminate\Support\Facades classes