### PR TITLE
feature: removes the coupling with laravel session

### DIFF
--- a/config/devices.php
+++ b/config/devices.php
@@ -4,24 +4,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cookie name for current user device tracking
+    | Parameter name for current user device tracking
     |--------------------------------------------------------------------------
-    | This option specifies the name of the cookie that will be used to store
+    | This option specifies the name of the cookie that will be used to transport
     | the device id of the current user.
     |
     */
-    'device_id_cookie_name' => 'laravel_device_id',
-
-
-    /*
-    |--------------------------------------------------------------------------
-    | Header name for device id
-    |--------------------------------------------------------------------------
-    | This option specifies the name of the header that will be used to store
-    | the device uuid during the request.
-    |
-    */
-    'device_id_header_name' => 'X-Device',
+    'device_id_parameter' => 'laravel_device_id',
 
     /*
     |--------------------------------------------------------------------------
@@ -29,41 +18,20 @@ return [
     |--------------------------------------------------------------------------
     | This option specifies the transport method for the device id.
     |
-    | Options: 'cookie', 'header'
+    | Options: 'cookie', 'header', 'session'
     |
     */
     'device_id_transport' => 'cookie',
 
     /*
     |--------------------------------------------------------------------------
-    | Request param for device id
+    | Parameter name for current user session tracking
     |--------------------------------------------------------------------------
-    | This option specifies the name of the request parameter that will be used to store
-    | the device uuid during the request.
-    |
-    */
-    'device_id_request_param' => 'laravel_device_id',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Cookie name for current user session tracking
-    |--------------------------------------------------------------------------
-    | This option specifies the name of the cookie that will be used to store
+    | This option specifies the name of the parameter that will be used to transport
     | the session id for the current user.
     |
     */
-    'session_id_cookie_name' => 'laravel_session_id',
-
-
-    /*
-    |--------------------------------------------------------------------------
-    | Header name for session id
-    |--------------------------------------------------------------------------
-    | This option specifies the name of the header that will be used to store
-    | the session id during the request.
-    |
-    */
-    'session_id_header_name' => 'X-Session',
+    'session_id_parameter' => 'laravel_session_id',
 
     /*
     |--------------------------------------------------------------------------
@@ -71,20 +39,10 @@ return [
     |--------------------------------------------------------------------------
     | This option specifies the transport method for the session id.
     |
-    | Options: 'cookie', 'header'
+    | Options: 'cookie', 'header', 'session'
     |
     */
     'session_id_transport' => 'cookie',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Request param for session id
-    |--------------------------------------------------------------------------
-    | This option specifies the name of the request parameter that will be used to store
-    | the session id during the request.
-    |
-    */
-    'session_id_request_param' => 'laravel_session_id',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/devices.php
+++ b/config/devices.php
@@ -12,15 +12,6 @@ return [
     */
     'device_id_cookie_name' => 'laravel_device_id',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Request param for device id
-    |--------------------------------------------------------------------------
-    | This option specifies the name of the request parameter that will be used to store
-    | the device uuid during the request.
-    |
-    */
-    'device_id_request_param' => 'laravel_device_id',
 
     /*
     |--------------------------------------------------------------------------
@@ -42,6 +33,58 @@ return [
     |
     */
     'device_id_transport' => 'cookie',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Request param for device id
+    |--------------------------------------------------------------------------
+    | This option specifies the name of the request parameter that will be used to store
+    | the device uuid during the request.
+    |
+    */
+    'device_id_request_param' => 'laravel_device_id',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cookie name for current user session tracking
+    |--------------------------------------------------------------------------
+    | This option specifies the name of the cookie that will be used to store
+    | the session id for the current user.
+    |
+    */
+    'session_id_cookie_name' => 'laravel_session_id',
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Header name for session id
+    |--------------------------------------------------------------------------
+    | This option specifies the name of the header that will be used to store
+    | the session id during the request.
+    |
+    */
+    'session_id_header_name' => 'X-Session',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Transport for session id
+    |--------------------------------------------------------------------------
+    | This option specifies the transport method for the session id.
+    |
+    | Options: 'cookie', 'header'
+    |
+    */
+    'session_id_transport' => 'cookie',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Request param for session id
+    |--------------------------------------------------------------------------
+    | This option specifies the name of the request parameter that will be used to store
+    | the session id during the request.
+    |
+    */
+    'session_id_request_param' => 'laravel_session_id',
 
     /*
     |--------------------------------------------------------------------------

--- a/helpers.php
+++ b/helpers.php
@@ -4,7 +4,8 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Session as SessionFacade;
 use Ninja\DeviceTracker\Contracts\StorableId;
-use Ninja\DeviceTracker\Enums\Transport;
+use Ninja\DeviceTracker\Enums\DeviceTransport;
+use Ninja\DeviceTracker\Enums\SessionTransport;
 use Ninja\DeviceTracker\Exception\SessionNotFoundException;
 use Ninja\DeviceTracker\Factories\SessionIdFactory;
 use Ninja\DeviceTracker\Models\Device;
@@ -25,15 +26,17 @@ if (! function_exists('fingerprint')) {
 if (! function_exists('device_uuid')) {
     function device_uuid(): ?StorableId
     {
-        return Transport::current()->get();
+        return DeviceTransport::current()->get();
     }
 }
 
 if (! function_exists('session_uuid')) {
     function session_uuid(): ?StorableId
     {
-        $id = SessionFacade::get(Session::DEVICE_SESSION_ID);
-        return $id ? SessionIdFactory::from($id) : null;
+        return SessionTransport::current()->get();
+
+        //$id = SessionFacade::get(Session::DEVICE_SESSION_ID);
+        //return $id ? SessionIdFactory::from($id) : null;
     }
 }
 

--- a/helpers.php
+++ b/helpers.php
@@ -34,21 +34,6 @@ if (! function_exists('session_uuid')) {
     function session_uuid(): ?StorableId
     {
         return SessionTransport::current()->get();
-
-        //$id = SessionFacade::get(Session::DEVICE_SESSION_ID);
-        //return $id ? SessionIdFactory::from($id) : null;
-    }
-}
-
-if (! function_exists('session')) {
-    function session(): ?Session
-    {
-        try {
-            $id = session_uuid();
-            return $id ? Session::byUuid($id) : null;
-        } catch (SessionNotFoundException) {
-            return null;
-        }
     }
 }
 

--- a/src/DeviceManager.php
+++ b/src/DeviceManager.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Contracts\StorableId;
-use Ninja\DeviceTracker\Enums\Transport;
+use Ninja\DeviceTracker\Enums\DeviceTransport;
 use Ninja\DeviceTracker\Events\DeviceAttachedEvent;
 use Ninja\DeviceTracker\Events\DeviceTrackedEvent;
 use Ninja\DeviceTracker\Exception\DeviceNotFoundException;
@@ -84,14 +84,14 @@ final class DeviceManager
         if (device_uuid()) {
             if (Config::get('devices.regenerate_devices')) {
                 event(new DeviceTrackedEvent(device_uuid()));
-                Transport::propagate(device_uuid());
+                DeviceTransport::propagate(device_uuid());
                 return device_uuid();
             } else {
                 throw new DeviceNotFoundException('Tracked device not found in database');
             }
         } else {
             $deviceUuid = DeviceIdFactory::generate();
-            Transport::propagate($deviceUuid);
+            DeviceTransport::propagate($deviceUuid);
             event(new DeviceTrackedEvent($deviceUuid));
 
             return $deviceUuid;

--- a/src/Enums/DeviceTransport.php
+++ b/src/Enums/DeviceTransport.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ninja\DeviceTracker\Enums;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Cookie;
+use Ninja\DeviceTracker\Contracts\StorableId;
+use Ninja\DeviceTracker\Factories\DeviceIdFactory;
+
+enum DeviceTransport: string
+{
+    use Traits\CanTransport;
+
+    case Cookie = 'cookie';
+    case Header = 'header';
+
+    public static function current(): self
+    {
+        $config = config('devices.device_id_transport', self::Cookie->value);
+        return self::tryFrom($config);
+    }
+
+    public function parameter(): string
+    {
+        return match ($this) {
+            self::Cookie => config('devices.device_id_cookie_name'),
+            self::Header => config('devices.device_id_header_name'),
+        };
+    }
+}

--- a/src/Enums/DeviceTransport.php
+++ b/src/Enums/DeviceTransport.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Session;
 use Ninja\DeviceTracker\Contracts\StorableId;
 use Ninja\DeviceTracker\Factories\DeviceIdFactory;
 
@@ -15,6 +17,8 @@ enum DeviceTransport: string
 
     case Cookie = 'cookie';
     case Header = 'header';
+
+    case Session = 'session';
 
     public static function current(): self
     {
@@ -27,6 +31,33 @@ enum DeviceTransport: string
         return match ($this) {
             self::Cookie => config('devices.device_id_cookie_name'),
             self::Header => config('devices.device_id_header_name'),
+            self::Session => config('devices.device_id_session_name'),
         };
+    }
+
+    private function fromCookie(): ?StorableId
+    {
+        return Cookie::has($this->parameter()) ? DeviceIdFactory::from(Cookie::get($this->parameter())) : null;
+    }
+
+    private function fromHeader(): ?StorableId
+    {
+        return request()->hasHeader($this->parameter()) ? DeviceIdFactory::from(request()->header($this->parameter())) : null;
+    }
+
+    private function fromSession(): ?StorableId
+    {
+        return Session::has($this->parameter()) ? DeviceIdFactory::from(Session::get($this->parameter())) : null;
+    }
+
+    private function requestParameter(): string
+    {
+        return config('devices.device_id_request_param');
+    }
+
+    private function fromRequest(): ?StorableId
+    {
+        $requestParameter = $this->requestParameter();
+        return request()->has($requestParameter) ? DeviceIdFactory::from(request()->input($requestParameter)) : null;
     }
 }

--- a/src/Enums/DeviceTransport.php
+++ b/src/Enums/DeviceTransport.php
@@ -15,6 +15,8 @@ enum DeviceTransport: string
 {
     use Traits\CanTransport;
 
+    private const DEFAULT_REQUEST_PARAMETER = 'internal_device_id';
+
     case Cookie = 'cookie';
     case Header = 'header';
 
@@ -26,13 +28,9 @@ enum DeviceTransport: string
         return self::tryFrom($config);
     }
 
-    public function parameter(): string
+    private function parameter(): string
     {
-        return match ($this) {
-            self::Cookie => config('devices.device_id_cookie_name'),
-            self::Header => config('devices.device_id_header_name'),
-            self::Session => config('devices.device_id_session_name'),
-        };
+        return config('devices.device_id_parameter');
     }
 
     private function fromCookie(): ?StorableId
@@ -50,14 +48,8 @@ enum DeviceTransport: string
         return Session::has($this->parameter()) ? DeviceIdFactory::from(Session::get($this->parameter())) : null;
     }
 
-    private function requestParameter(): string
-    {
-        return config('devices.device_id_request_param');
-    }
-
     private function fromRequest(): ?StorableId
     {
-        $requestParameter = $this->requestParameter();
-        return request()->has($requestParameter) ? DeviceIdFactory::from(request()->input($requestParameter)) : null;
+        return request()->has(self::DEFAULT_REQUEST_PARAMETER) ? DeviceIdFactory::from(request()->input(self::DEFAULT_REQUEST_PARAMETER)) : null;
     }
 }

--- a/src/Enums/SessionTransport.php
+++ b/src/Enums/SessionTransport.php
@@ -2,7 +2,10 @@
 
 namespace Ninja\DeviceTracker\Enums;
 
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Session;
 use Ninja\DeviceTracker\Contracts\StorableId;
+use Ninja\DeviceTracker\Factories\SessionIdFactory;
 
 enum SessionTransport: string
 {
@@ -11,18 +14,21 @@ enum SessionTransport: string
     case Cookie = 'cookie';
     case Header = 'header';
 
+    case Session = 'session';
+
     public static function current(): self
     {
         $config = config('devices.session_id_transport', self::Cookie->value);
         return self::tryFrom($config);
     }
 
-    public function get(): ?StorableId
+    public static function forget(): void
     {
-        return match ($this) {
-            self::Cookie => $this->fromCookie(),
-            self::Header => $this->fromHeader(),
-        } ?? $this->fromRequest();
+        match (self::current()) {
+            self::Cookie => Cookie::queue(Cookie::forget(self::current()->parameter())),
+            self::Header => null,
+            self::Session => Session::forget(self::current()->parameter()),
+        };
     }
 
     public function parameter(): string
@@ -30,6 +36,35 @@ enum SessionTransport: string
         return match ($this) {
             self::Cookie => config('devices.session_id_cookie_name'),
             self::Header => config('devices.session_id_header_name'),
+            self::Session => config('devices.session_id_session_name'),
         };
+    }
+
+    private function requestParameter(): string
+    {
+        return config('devices.session_id_request_param');
+    }
+
+    private function fromCookie(): ?StorableId
+    {
+        return Cookie::has($this->parameter()) ? SessionIdFactory::from(Cookie::get($this->parameter())) : null;
+    }
+
+    private function fromHeader(): ?StorableId
+    {
+        return request()->hasHeader($this->parameter()) ? SessionIdFactory::from(request()->header($this->parameter())) : null;
+    }
+
+    private function fromSession(): ?StorableId
+    {
+
+        return Session::has($this->parameter()) ? SessionIdFactory::from(Session::get($this->parameter())) : null;
+    }
+
+
+    private function fromRequest(): ?StorableId
+    {
+        $requestParameter = $this->requestParameter();
+        return request()->has($requestParameter) ? SessionIdFactory::from(request()->input($requestParameter)) : null;
     }
 }

--- a/src/Enums/SessionTransport.php
+++ b/src/Enums/SessionTransport.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ninja\DeviceTracker\Enums;
+
+use Ninja\DeviceTracker\Contracts\StorableId;
+
+enum SessionTransport: string
+{
+    use Traits\CanTransport;
+
+    case Cookie = 'cookie';
+    case Header = 'header';
+
+    public static function current(): self
+    {
+        $config = config('devices.session_id_transport', self::Cookie->value);
+        return self::tryFrom($config);
+    }
+
+    public function get(): ?StorableId
+    {
+        return match ($this) {
+            self::Cookie => $this->fromCookie(),
+            self::Header => $this->fromHeader(),
+        } ?? $this->fromRequest();
+    }
+
+    public function parameter(): string
+    {
+        return match ($this) {
+            self::Cookie => config('devices.session_id_cookie_name'),
+            self::Header => config('devices.session_id_header_name'),
+        };
+    }
+}

--- a/src/Enums/SessionTransport.php
+++ b/src/Enums/SessionTransport.php
@@ -11,6 +11,8 @@ enum SessionTransport: string
 {
     use Traits\CanTransport;
 
+    private const DEFAULT_REQUEST_PARAMETER = 'internal_session_id';
+
     case Cookie = 'cookie';
     case Header = 'header';
 
@@ -31,18 +33,9 @@ enum SessionTransport: string
         };
     }
 
-    public function parameter(): string
+    private function parameter(): string
     {
-        return match ($this) {
-            self::Cookie => config('devices.session_id_cookie_name'),
-            self::Header => config('devices.session_id_header_name'),
-            self::Session => config('devices.session_id_session_name'),
-        };
-    }
-
-    private function requestParameter(): string
-    {
-        return config('devices.session_id_request_param');
+        return config('devices.session_id_parameter');
     }
 
     private function fromCookie(): ?StorableId
@@ -64,7 +57,6 @@ enum SessionTransport: string
 
     private function fromRequest(): ?StorableId
     {
-        $requestParameter = $this->requestParameter();
-        return request()->has($requestParameter) ? SessionIdFactory::from(request()->input($requestParameter)) : null;
+        return request()->has(self::DEFAULT_REQUEST_PARAMETER) ? SessionIdFactory::from(request()->input(self::DEFAULT_REQUEST_PARAMETER)) : null;
     }
 }

--- a/src/Enums/Traits/CanTransport.php
+++ b/src/Enums/Traits/CanTransport.php
@@ -59,7 +59,7 @@ trait CanTransport
         $current = self::current();
         $id = $id ?? $current->get();
 
-        $requestParameter = $current->requestParameter();
+        $requestParameter = self::DEFAULT_REQUEST_PARAMETER;
 
         return request()->merge([$requestParameter => (string) $id ?? $current->get()->toString()]);
     }

--- a/src/Http/Middleware/DeviceTracker.php
+++ b/src/Http/Middleware/DeviceTracker.php
@@ -5,7 +5,7 @@ namespace Ninja\DeviceTracker\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Ninja\DeviceTracker\Enums\Transport;
+use Ninja\DeviceTracker\Enums\DeviceTransport;
 use Ninja\DeviceTracker\Exception\DeviceNotFoundException;
 use Ninja\DeviceTracker\Exception\FingerprintNotFoundException;
 use Ninja\DeviceTracker\Exception\UnknownDeviceDetectedException;
@@ -20,7 +20,7 @@ final readonly class DeviceTracker
             DeviceManager::create();
             DeviceManager::attach();
 
-            return $next(Transport::propagate(device_uuid()));
+            return $next(DeviceTransport::propagate(device_uuid()));
         }
 
         if (!DeviceManager::tracked()) {
@@ -29,7 +29,7 @@ final readonly class DeviceTracker
                     DeviceManager::track();
                     DeviceManager::create();
                 } else {
-                    Transport::propagate(DeviceIdFactory::generate());
+                    DeviceTransport::propagate(DeviceIdFactory::generate());
                 }
             } catch (DeviceNotFoundException | FingerprintNotFoundException | UnknownDeviceDetectedException $e) {
                 Log::info($e->getMessage());
@@ -37,6 +37,6 @@ final readonly class DeviceTracker
             }
         }
 
-        return Transport::set($next(Transport::propagate(device_uuid())), device_uuid());
+        return DeviceTransport::set($next(DeviceTransport::propagate(device_uuid())), device_uuid());
     }
 }

--- a/src/Http/Middleware/SessionTracker.php
+++ b/src/Http/Middleware/SessionTracker.php
@@ -66,7 +66,7 @@ final readonly class SessionTracker
         try {
             return redirect()->route(Config::get('devices.logout_route_name'));
         } catch (RouteNotFoundException $e) {
-            Log::error('Point not found', ['route' => Config::get('devices.logout_route_name'), 'exception' => $e]);
+            Log::error('Route not found', ['route' => Config::get('devices.logout_route_name'), 'exception' => $e]);
         }
 
         return response()->json(['message' => 'Unauthorized'], 401);
@@ -90,7 +90,7 @@ final readonly class SessionTracker
         try {
             return redirect()->route(Config::get('devices.2fa_route_name'));
         } catch (RouteNotFoundException $e) {
-            Log::error('Point not found', ['route' => Config::get('devices.2fa_route_name'), 'exception' => $e]);
+            Log::error('Route not found', ['route' => Config::get('devices.2fa_route_name'), 'exception' => $e]);
         }
 
         return response()->json(['message' => 'Session locked'], 423);

--- a/src/Models/Relations/HasManySessions.php
+++ b/src/Models/Relations/HasManySessions.php
@@ -40,8 +40,8 @@ final class HasManySessions extends HasMany
     {
         return $this
             ->with('device')
-            ->where('status', SessionStatus::Active)
-            ->orderBy('last_activity_at', 'desc')
+            ->where('status', SessionStatus::Active->value)
+            ->orderByDesc('last_activity_at')
             ->get()
             ->first();
     }

--- a/src/Models/Session.php
+++ b/src/Models/Session.php
@@ -17,6 +17,7 @@ use Ninja\DeviceTracker\Contracts\Cacheable;
 use Ninja\DeviceTracker\Contracts\StorableId;
 use Ninja\DeviceTracker\DTO\Metadata;
 use Ninja\DeviceTracker\Enums\SessionStatus;
+use Ninja\DeviceTracker\Enums\SessionTransport;
 use Ninja\DeviceTracker\Events\SessionBlockedEvent;
 use Ninja\DeviceTracker\Events\SessionFinishedEvent;
 use Ninja\DeviceTracker\Events\SessionStartedEvent;
@@ -163,7 +164,10 @@ class Session extends Model implements Cacheable
             'last_activity_at' => $now,
         ]);
 
-        SessionFacade::put(self::DEVICE_SESSION_ID, $session->uuid);
+        SessionTransport::propagate($session->uuid);
+        SessionTransport::current()->set(response(), $session->uuid);
+
+        //SessionFacade::put(self::DEVICE_SESSION_ID, $session->uuid);
         event(new SessionStartedEvent($session, Auth::user()));
 
         return $session;

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Session as SessionFacade;
 use Ninja\DeviceTracker\Contracts\StorableId;
 use Ninja\DeviceTracker\Exception\DeviceNotFoundException;
 use Ninja\DeviceTracker\Exception\SessionNotFoundException;
@@ -133,7 +132,6 @@ final readonly class SessionManager
     {
         if (session_uuid() !== null) {
             Session::destroy(session_uuid());
-            SessionFacade::forget(Session::DEVICE_SESSION_ID);
         }
     }
 }

--- a/src/Traits/HasDevices.php
+++ b/src/Traits/HasDevices.php
@@ -5,7 +5,7 @@ namespace Ninja\DeviceTracker\Traits;
 use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Factories\DeviceIdFactory;
 use Ninja\DeviceTracker\Models\Device;
-use Ninja\DeviceTracker\Models\HasManySessions;
+use Ninja\DeviceTracker\Models\Relations\HasManySessions;
 use Ninja\DeviceTracker\Models\Relations\BelongsToManyDevices;
 use Ninja\DeviceTracker\Models\Session;
 

--- a/src/Traits/HasDevices.php
+++ b/src/Traits/HasDevices.php
@@ -5,8 +5,8 @@ namespace Ninja\DeviceTracker\Traits;
 use Illuminate\Support\Facades\Config;
 use Ninja\DeviceTracker\Factories\DeviceIdFactory;
 use Ninja\DeviceTracker\Models\Device;
+use Ninja\DeviceTracker\Models\HasManySessions;
 use Ninja\DeviceTracker\Models\Relations\BelongsToManyDevices;
-use Ninja\DeviceTracker\Models\Relations\HasManySessions;
 use Ninja\DeviceTracker\Models\Session;
 
 trait HasDevices


### PR DESCRIPTION
- Removes the mandatory use of Laravel session to work
- Adds a new transport for session/device ids: session
- Dedicated transport enums for session and device ids