### PR TITLE
Reviewed session tracker middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "name": "Diego Rin Martín",
             "email": "yosoy@diego.ninja"
+        },
+        {
+            "name": "Davide Pizzato",
+            "email": "davide.pizzato@kimiagroup.com"
         }
     ],
     "require": {

--- a/src/EventSubscriber.php
+++ b/src/EventSubscriber.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Facades\Log;
+use Ninja\DeviceTracker\Enums\SessionTransport;
 use Ninja\DeviceTracker\Events\DeviceTrackedEvent;
 use Ninja\DeviceTracker\Events\Google2FASuccess;
 use Ninja\DeviceTracker\Exception\DeviceNotFoundException;
@@ -34,7 +35,8 @@ final readonly class EventSubscriber
                 throw new DeviceNotFoundException('Failed to attach device during login');
             }
 
-            SessionManager::refresh($event->user);
+            $session = SessionManager::refresh($event->user);
+            SessionTransport::propagate($session?->uuid);
         } catch (DeviceNotFoundException $e) {
             Log::error('Login failed due to device error', [
                 'error' => $e->getMessage(),

--- a/src/Facades/SessionManager.php
+++ b/src/Facades/SessionManager.php
@@ -14,12 +14,12 @@ use Ninja\DeviceTracker\Models\Session;
  * @method static bool end(?StorableId $sessionId = null, ?Authenticatable $user = null)
  * @method static bool renew(Authenticatable $user)
  * @method static bool restart(Request $request)
- * @method static bool refresh(?Authenticatable $user = null)
+ * @method static Session refresh(?Authenticatable $user = null)
  * @method static bool inactive(?Authenticatable $user = null)
  * @method static bool block(StorableId $sessionId)
  * @method static bool blocked(StorableId $sessionId)
  * @method static bool locked(StorableId $sessionId)
- * @method static bool delete()
+ * @method static void delete()
  */
 final class SessionManager extends Facade
 {


### PR DESCRIPTION
Changes:

- OnLogin now start the session and set it so the session_uuid is available everywhere
- SessionTracker will try to execute the api before creating a session when no user is logged to allow login api to actually send back the session id in the response