### PR TITLE
fix: fix a bug where user not logged and session set would cause error 500

### DIFF
--- a/src/Facades/SessionManager.php
+++ b/src/Facades/SessionManager.php
@@ -10,7 +10,7 @@ use Ninja\DeviceTracker\Models\Session;
 
 /**
  * @method static Session|null current()
- * @method static Session start()
+ * @method static Session start(?Authenticatable $user = null)
  * @method static bool end(?StorableId $sessionId = null, ?Authenticatable $user = null)
  * @method static bool renew(Authenticatable $user)
  * @method static bool restart(Request $request)

--- a/src/Http/Middleware/SessionTracker.php
+++ b/src/Http/Middleware/SessionTracker.php
@@ -244,7 +244,7 @@ final readonly class SessionTracker
     private function startNewSession(Session $session): Session
     {
         $session->end();
-        $session = SessionManager::start();
+        $session = SessionManager::start($session->user);
 
         SessionTransport::propagate($session->uuid);
 

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -31,7 +31,7 @@ final readonly class SessionManager
     /**
      * @throws DeviceNotFoundException
      */
-    public function start(): Session
+    public function start(?Authenticatable $user = null): Session
     {
         $device = DeviceManager::current();
         if (! $device) {
@@ -42,7 +42,10 @@ final readonly class SessionManager
             throw new DeviceNotFoundException('Device is flagged as hijacked.');
         }
 
-        return Session::start(device: $device);
+        return Session::start(
+            device: $device,
+            user: $user,
+        );
     }
 
     public function end(?StorableId $sessionId = null, ?Authenticatable $user = null): bool
@@ -80,13 +83,13 @@ final readonly class SessionManager
     {
         $current = Session::current();
         if (! $current) {
-            return $this->start();
+            return $this->start($user);
         }
 
         if (Config::get('devices.start_new_session_on_login')) {
             $current->end($user);
 
-            return $this->start();
+            return $this->start($user);
         }
 
         $current->renew($user);


### PR DESCRIPTION
The session tracker should be able to keep track of the session even if the user is not logged in but the session is provided in the request.