### PR TITLE
Add check for soft deleted user when renewing/logging out a finished session

### DIFF
--- a/src/Enums/DeviceTransport.php
+++ b/src/Enums/DeviceTransport.php
@@ -35,6 +35,8 @@ enum DeviceTransport: string
         }
 
         self::cleanRequestHierarchy($hierarchy);
+        // Clean any propagation
+        self::Request->clean();
     }
 
     public static function responseTransport(): self

--- a/src/Enums/DeviceTransport.php
+++ b/src/Enums/DeviceTransport.php
@@ -27,6 +27,16 @@ enum DeviceTransport: string
         return self::currentFromHierarchy($hierarchy, self::Cookie);
     }
 
+    public static function cleanRequest(): void
+    {
+        $hierarchy = config('devices.device_id_transport_hierarchy', [self::Cookie->value]);
+        if (empty($hierarchy)) {
+            $hierarchy = [self::Cookie->value];
+        }
+
+        self::cleanRequestHierarchy($hierarchy);
+    }
+
     public static function responseTransport(): self
     {
         $responseTransportString = config('devices.device_id_response_transport', self::Cookie->value);

--- a/src/Enums/SessionTransport.php
+++ b/src/Enums/SessionTransport.php
@@ -35,6 +35,8 @@ enum SessionTransport: string
         }
 
         self::cleanRequestHierarchy($hierarchy);
+        // Clean any propagation
+        self::Request->clean();
     }
 
     public static function responseTransport(): self

--- a/src/Enums/SessionTransport.php
+++ b/src/Enums/SessionTransport.php
@@ -27,6 +27,16 @@ enum SessionTransport: string
         return self::currentFromHierarchy($hierarchy, self::Cookie);
     }
 
+    public static function cleanRequest(): void
+    {
+        $hierarchy = config('devices.session_id_transport_hierarchy', [self::Cookie->value]);
+        if (empty($hierarchy)) {
+            $hierarchy = [self::Cookie->value];
+        }
+
+        self::cleanRequestHierarchy($hierarchy);
+    }
+
     public static function responseTransport(): self
     {
         $responseTransportString = config('devices.session_id_response_transport', self::Cookie->value);

--- a/src/Enums/Traits/CanTransport.php
+++ b/src/Enums/Traits/CanTransport.php
@@ -283,6 +283,7 @@ trait CanTransport
 
     private function cleanFromRequest(?string $parameter = null): void
     {
+        $parameter ??= self::parameter();
         request()->merge([$parameter => null]);
     }
 

--- a/src/Enums/Traits/CanTransport.php
+++ b/src/Enums/Traits/CanTransport.php
@@ -29,6 +29,19 @@ trait CanTransport
         }
     }
 
+    public function clean(?string $parameter = null): void
+    {
+        try {
+            match ($this) {
+                self::Cookie => $this->cleanFromCookie($parameter),
+                self::Header => $this->cleanFromHeader($parameter),
+                self::Session => $this->cleanFromSession($parameter),
+                self::Request => $this->cleanFromRequest($parameter),
+            };
+        } catch (Throwable) {
+        }
+    }
+
     public static function currentFromHierarchy(array $hierarchy, self $default): self
     {
         $defaultTransport = null;
@@ -74,6 +87,16 @@ trait CanTransport
         }
 
         return null;
+    }
+
+    protected static function cleanRequestHierarchy(array $hierarchy): void
+    {
+        foreach ($hierarchy as $item) {
+            $transport = self::tryFrom($item);
+            if (! is_null($transport)) {
+                $transport->clean();
+            }
+        }
     }
 
     public static function set(mixed $response, StorableId $id): mixed
@@ -241,6 +264,26 @@ trait CanTransport
         }
 
         return $id;
+    }
+
+    private function cleanFromCookie(?string $parameter = null): void
+    {
+        Cookie::forget($parameter ?? self::parameter());
+    }
+
+    private function cleanFromHeader(?string $parameter = null): void
+    {
+        request()->headers->remove($parameter ?? self::parameter());
+    }
+
+    private function cleanFromSession(?string $parameter = null): void
+    {
+        Session::forget($parameter ?? self::parameter());
+    }
+
+    private function cleanFromRequest(?string $parameter = null): void
+    {
+        request()->merge([$parameter => null]);
     }
 
     public static function forget(): void

--- a/src/Http/Middleware/SessionTracker.php
+++ b/src/Http/Middleware/SessionTracker.php
@@ -148,7 +148,7 @@ final readonly class SessionTracker
         if (null === $session->user) {
             $session->end();
             $session = null;
-            SessionTransport::propagate();
+            SessionTransport::cleanRequest();
             SessionTransport::forget();
         }
 


### PR DESCRIPTION
Soft delete could cause user to be not defined in the relation. In that case logout is the only acceptable option