### PR TITLE
Fix Auth Helper

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -86,6 +86,6 @@ if (! function_exists('guard')) {
 if (! function_exists('user')) {
     function user(): ?Authenticatable
     {
-        return guard()->hasUser() ? guard()->user() : null;
+        return auth()->check() ? auth()->user() : null;
     }
 }


### PR DESCRIPTION
In reference to this comment: https://github.com/diego-ninja/laravel-devices/issues/9#issuecomment-2958084396

The usage of `guard()->hasUser()` is notorious for returning a lot of false positives, I'd suggest sticking with the auth() guard directly & then returning that Auth contract