### PR TITLE
Add some new config option to try to improve performances

### DIFF
--- a/config/devices.php
+++ b/config/devices.php
@@ -655,4 +655,54 @@ return [
         'Mozilla/5.0 (Linux; Android 13; 2211133G Build/TKQ1.220905.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/113.0.5672.76 Mobile Safari/537.36',
         'Mozilla/5.0 (Linux; U; Android 13; pl-pl; Xiaomi 13 Build/TKQ1.220905.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.127 Mobile Safari/537.36 XiaoMi/MiuiBrowser/13.28.0-gn',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Devices table
+    |--------------------------------------------------------------------------
+    |
+    | This options makes the user_devices table update when needed.
+    | Table name is build like this: `{singular device.authenticatable_table}_devices`
+    |
+    */
+    'user_devices' => [
+        'enabled' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Performance
+    |--------------------------------------------------------------------------
+    |
+    | This options allows to configure the package performances
+    |
+    */
+    'performance' => [
+        'session' => [
+            /*
+            |--------------------------------------------------------------------------
+            | Always Sync Last Activity
+            |--------------------------------------------------------------------------
+            |
+            | This option makes the last_activity_at field always update on each request.
+            | When disabled, the last_activity_at field is updated only when a request
+            | is received after at least `last_activity_update_interval` seconds.
+            |
+            */
+            'always_sync_last_activity' => true,
+
+            /*
+            |--------------------------------------------------------------------------
+            | Last Activity Update Interval
+            |--------------------------------------------------------------------------
+            |
+            | This option sets the minimum amount of seconds to wait between each
+            | `last_activity_at` session field update when the `always_sync_last_activity`
+            | is false. This is useful when trying to limit the number of queries that
+            | are run by this package.
+            |
+            */
+            'last_activity_update_interval' => 300,
+        ],
+    ],
 ];

--- a/src/DeviceManager.php
+++ b/src/DeviceManager.php
@@ -181,4 +181,9 @@ final class DeviceManager
 
         return null;
     }
+
+    public function userDevicesTableEnabled(): bool
+    {
+        return config('devices.user_devices.enabled', true);
+    }
 }

--- a/src/Facades/DeviceManager.php
+++ b/src/Facades/DeviceManager.php
@@ -2,24 +2,10 @@
 
 namespace Ninja\DeviceTracker\Facades;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Facade;
-use Ninja\DeviceTracker\Contracts\StorableId;
-use Ninja\DeviceTracker\DTO\Device as DeviceDto;
-use Ninja\DeviceTracker\Models\Device;
 
 /**
- * @method static Device|null current()
- * @method static bool isUserDevice(StorableId $deviceUuid)
- * @method static Collection<int,Device> userDevices()
- * @method static bool attach(?StorableId $deviceUuid = null)
- * @method static Device create(?StorableId $deviceId = null)
- * @method static StorableId track()
- * @method static bool tracked()
- * @method static bool fingerprinted()
- * @method static bool shouldRegenerate()
- * @method static DeviceDto|null detect()
- * @method static bool isWhitelisted(string|null $userAgent)
+ * @mixin \Ninja\DeviceTracker\DeviceManager
  */
 final class DeviceManager extends Facade
 {

--- a/src/Facades/SessionManager.php
+++ b/src/Facades/SessionManager.php
@@ -2,24 +2,10 @@
 
 namespace Ninja\DeviceTracker\Facades;
 
-use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
-use Ninja\DeviceTracker\Contracts\StorableId;
-use Ninja\DeviceTracker\Models\Session;
 
 /**
- * @method static Session|null current()
- * @method static Session start(?Authenticatable $user = null)
- * @method static bool end(?StorableId $sessionId = null, ?Authenticatable $user = null)
- * @method static bool renew(Authenticatable $user)
- * @method static bool restart(Request $request)
- * @method static Session refresh(?Authenticatable $user = null)
- * @method static bool inactive(?Authenticatable $user = null)
- * @method static bool block(StorableId $sessionId)
- * @method static bool blocked(StorableId $sessionId)
- * @method static bool locked(StorableId $sessionId)
- * @method static void delete()
+ * @mixin \Ninja\DeviceTracker\SessionManager
  */
 final class SessionManager extends Facade
 {

--- a/src/Http/Middleware/SessionTracker.php
+++ b/src/Http/Middleware/SessionTracker.php
@@ -74,6 +74,7 @@ final readonly class SessionTracker
             if (guard()->check()) {
                 // The login api could have been called again, get again the session to get the latest active one
                 $session = device_session();
+
                 return SessionTransport::set($response, $session->uuid);
             }
 
@@ -145,7 +146,7 @@ final readonly class SessionTracker
         $session = device_session();
 
         // This could happen if the user has been soft-deleted
-        if (null !== $session && null === $session->user) {
+        if ($session !== null && $session->user === null) {
             $session->end();
             $session = null;
             SessionTransport::cleanRequest();
@@ -218,7 +219,7 @@ final readonly class SessionTracker
 
     private function manageSessionLocationChange(Request $request, Session $session): Session
     {
-        if ( ! $this->changedLocation($request, $session)) {
+        if (! $this->changedLocation($request, $session)) {
             return $session;
         }
 
@@ -250,10 +251,7 @@ final readonly class SessionTracker
 
     private function relocateSession(Session $session): Session
     {
-        $session = $session->relocate();
-        $session->save();
-
-        return $session;
+        return $session->relocate();
     }
 
     private function startNewSession(Session $session): Session

--- a/src/Models/Device.php
+++ b/src/Models/Device.php
@@ -33,6 +33,7 @@ use Ninja\DeviceTracker\Events\DeviceUpdatedEvent;
 use Ninja\DeviceTracker\Events\DeviceVerifiedEvent;
 use Ninja\DeviceTracker\Exception\DeviceNotFoundException;
 use Ninja\DeviceTracker\Exception\FingerprintDuplicatedException;
+use Ninja\DeviceTracker\Facades\DeviceManager;
 use Ninja\DeviceTracker\Factories\DeviceIdFactory;
 use Ninja\DeviceTracker\Models\Relations\HasManySessions;
 use Ninja\DeviceTracker\Modules\Tracking\Models\Event;
@@ -228,11 +229,13 @@ class Device extends Model implements Cacheable
 
         $user = $user ?? user();
 
-        $this->users()->updateExistingPivot($user?->getAuthIdentifier(), [
-            'device_uuid' => $this->uuid,
-            'status' => DeviceStatus::Verified,
-            'verified_at' => now(),
-        ]);
+        if (DeviceManager::userDevicesTableEnabled()) {
+            $this->users()->updateExistingPivot($user?->getAuthIdentifier(), [
+                'device_uuid' => $this->uuid,
+                'status' => DeviceStatus::Verified,
+                'verified_at' => now(),
+            ]);
+        }
 
         $this->sessions
             ->where('status', SessionStatus::Locked)
@@ -283,9 +286,11 @@ class Device extends Model implements Cacheable
 
         $this->hijacked_at = now();
 
-        $this->users()->updateExistingPivot($user?->getAuthIdentifier(), [
-            'status' => DeviceStatus::Hijacked,
-        ]);
+        if (DeviceManager::userDevicesTableEnabled()) {
+            $this->users()->updateExistingPivot($user?->getAuthIdentifier(), [
+                'status' => DeviceStatus::Hijacked,
+            ]);
+        }
 
         foreach ($this->sessions as $session) {
             $session->block();

--- a/src/SessionManager.php
+++ b/src/SessionManager.php
@@ -142,4 +142,14 @@ final readonly class SessionManager
             Session::destroy(session_uuid());
         }
     }
+
+    public function alwaysSyncLastActivity(): bool
+    {
+        return config('devices.performance.session.always_sync_last_activity', true);
+    }
+
+    public function lastActivityUpdateInterval(): int
+    {
+        return (int) config('devices.performance.session.last_activity_update_interval', 300);
+    }
 }


### PR DESCRIPTION
Add new options to config to allow for some performance improvements in case of need.

- `user_devices.enabled` -> to avoid updates of the user_devices table if not used
- `performance.session.always_sync_last_activity` -> to decide wether to update the last_activity_at or not each time a request is received
- `performance.session.last_activity_update_interval` -> the seconds to wait before last_activity_at updates