### PR TITLE
Add support for pragmarx/google2fa v9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laravel/framework": "^10 || ^11 || ^12",
         "matomo/device-detector": "^6.4",
         "nesbot/carbon": "^2 || ^3",
-        "pragmarx/google2fa": "^8.0",
+        "pragmarx/google2fa": "^8.0|^9.0",
         "ramsey/uuid": "^4.7",
         "zero-to-prod/data-model": "^81.7"
     },


### PR DESCRIPTION
Updated composer.json to support both pragmarx/google2fa ^8.0 and ^9.0 to maintain compatibility with Laravel Fortify which requires ^9.0.

All tests pass with google2fa v9.0.0 installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google2FA dependency to support both version 8.0 and 9.0, broadening compatibility and allowing for more flexible version requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->